### PR TITLE
Remove navItems3 code causing warnings

### DIFF
--- a/includes/nav.php
+++ b/includes/nav.php
@@ -23,16 +23,4 @@
 		  	?>
 		</div>
 	</li>
-	<!--<li class="nav-item dropdown">
-		<a class="nav-link dropdown-toggle drpdwn" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Datingtips</a>
-		<div class="dropdown-menu" aria-labelledby="navbarDropdown">
-		  	<?php
-
-		    	foreach ($navItems3 as $item3) {
-		      		echo "<a class=\"dropdown-item\" href=\"$item3[slug]\">$item3[title]</a>";
-		    	}
-		    
-		  	?>
-		</div>
-	</li>-->
 </ul>


### PR DESCRIPTION
## Summary
- remove dangling navItems3 dropdown from `nav.php`
- purge `php_errorlog` entries for navItems3 warnings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684aafe035c48324b9703d05ac568fca