### PR TITLE
Add API base URLs for UK and DE

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ Broncode 18D
 
 Set the `APP_DEBUG` environment variable to `true` to display PHP errors. In
 production this variable should be unset or `false` so that errors are hidden.
+
+### API configuration
+
+The application communicates with different API endpoints depending on the
+country. Base URLs can be overridden using environment variables:
+
+- `API_BASE_URL_DEFAULT` - default API endpoint
+- `API_BASE_URL_BE` - Belgium specific endpoint
+- `API_BASE_URL_UK` - United Kingdom specific endpoint
+- `API_BASE_URL_DE` - Germany specific endpoint

--- a/config.php
+++ b/config.php
@@ -1,0 +1,36 @@
+<?php
+// Configuration for API endpoints
+
+// Base API URL used for most countries. Can be overridden via environment variable
+$API_BASE_DEFAULT = getenv('API_BASE_URL_DEFAULT') ?: 'https://16hl07csd16.nl';
+
+// Base API URL for Belgium. Can also be overridden
+$API_BASE_BE = getenv('API_BASE_URL_BE') ?: 'https://20fhbe2020.be';
+
+// Base API URL for the United Kingdom
+$API_BASE_UK = getenv('API_BASE_URL_UK') ?: 'https://22mlf09mds22.com';
+
+// Base API URL for Germany
+$API_BASE_DE = getenv('API_BASE_URL_DE') ?: 'https://23mlf01ccde23.com';
+
+/**
+ * Returns the API base URL for a given country code.
+ * If no specific base is defined for the country, the default is returned.
+ *
+ * @param string $country two-letter country code
+ * @return string
+ */
+function api_base($country = '') {
+    global $API_BASE_DEFAULT, $API_BASE_BE, $API_BASE_UK, $API_BASE_DE;
+
+    switch (strtolower($country)) {
+        case 'be':
+            return $API_BASE_BE;
+        case 'uk':
+            return $API_BASE_UK;
+        case 'de':
+            return $API_BASE_DE;
+        default:
+            return $API_BASE_DEFAULT;
+    }
+}

--- a/profile.php
+++ b/profile.php
@@ -1,6 +1,7 @@
 <?php
 	define("TITLE", "Daten");
-	include('includes/header.php');
+        include('includes/header.php');
+        include('config.php');
 ?>
 <!-- Page Content -->
     <div class="container" id="profiel">
@@ -36,15 +37,15 @@
   $country = isset($_GET['country']) ? $_GET['country'] : '';
   switch ($country) {
     case 'nl':
-      $api_url = 'https://16hl07csd16.nl/profile/get0/6/';
+      $api_url = api_base('nl') . '/profile/get0/6/';
       $ref_id = '32';
       break;
     case 'be':
-      $api_url = 'https://20fhbe2020.be/profile/get0/7/';
+      $api_url = api_base('be') . '/profile/get0/7/';
       $ref_id = '32';
       break;
     default:
-      $api_url = 'https://16hl07csd16.nl/profile/get/';
+      $api_url = api_base() . '/profile/get/';
       $ref_id = '32';
   }
 ?>

--- a/prov-at.php
+++ b/prov-at.php
@@ -2,7 +2,8 @@
         define("TITLE", "Daten in");
 
   include('includes/arr_prov_at.php');
-        include('includes/header.php');
+  include('includes/header.php');
+  include('config.php');
 
         function strip_bad_chars( $input ) {
                 $output = preg_replace("/[^a-zA-Z0-9_-]/", "",$input);
@@ -39,7 +40,7 @@
             <a :href="'profile.php?country=at&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "https://16hl07csd16.nl/profile/province_age/at/<?=$provat['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('at'); ?>/profile/province_age/at/<?=$provat['name']?>/18/45/120/S";
         </script>
 
         <!-- Pagination -->

--- a/prov-be.php
+++ b/prov-be.php
@@ -2,7 +2,8 @@
 	define("TITLE", "Daten in");
 
   include('includes/arr_prov_be.php');
-	include('includes/header.php');
+  include('includes/header.php');
+  include('config.php');
 
 	function strip_bad_chars( $input ) {
 		$output = preg_replace( "/[^a-zA-Z0-9_-]/", "",$input);
@@ -44,7 +45,7 @@
         </div>
       </div>
       <script>
-        var api_url= "https://20fhbe2020.be/profile/province_age/be/<?=$provbe['name']?>/18/45/120/S";
+        var api_url= "<?= api_base('be'); ?>/profile/province_age/be/<?=$provbe['name']?>/18/45/120/S";
       </script>
 
       <!-- Pagination -->

--- a/prov-ch.php
+++ b/prov-ch.php
@@ -2,7 +2,8 @@
         define("TITLE", "Daten in");
 
   include('includes/arr_prov_ch.php');
-        include('includes/header.php');
+  include('includes/header.php');
+  include('config.php');
 
         function strip_bad_chars( $input ) {
                 $output = preg_replace("/[^a-zA-Z0-9_-]/", "",$input);
@@ -39,7 +40,7 @@
             <a :href="'profile.php?country=ch&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "https://16hl07csd16.nl/profile/province_age/ch/<?=$provch['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('ch'); ?>/profile/province_age/ch/<?=$provch['name']?>/18/45/120/S";
         </script>
 
         <!-- Pagination -->

--- a/prov-de.php
+++ b/prov-de.php
@@ -2,7 +2,8 @@
         define("TITLE", "Daten in");
 
   include('includes/arr_prov_de.php');
-        include('includes/header.php');
+  include('includes/header.php');
+  include('config.php');
 
         function strip_bad_chars( $input ) {
                 $output = preg_replace("/[^a-zA-Z0-9_-]/", "",$input);
@@ -39,7 +40,7 @@
             <a :href="'profile.php?country=de&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "https://16hl07csd16.nl/profile/province_age/de/<?=$provde['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('de'); ?>/profile/province_age/de/<?=$provde['name']?>/18/45/120/S";
         </script>
 
         <!-- Pagination -->

--- a/prov-nl.php
+++ b/prov-nl.php
@@ -3,7 +3,8 @@
 
   include('includes/arr_prov_nl.php');
   include('includes/arr_prov_be.php');
-	include('includes/header.php');
+  include('includes/header.php');
+  include('config.php');
 
 	function strip_bad_chars( $input ) {
 		$output = preg_replace( "/[^a-zA-Z0-9_-]/", "",$input);
@@ -40,7 +41,7 @@
             <a :href="'profile.php?country=nl&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "https://16hl07csd16.nl/profile/province_age/nl/<?=$provnl['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('nl'); ?>/profile/province_age/nl/<?=$provnl['name']?>/18/45/120/S";
         </script>
 
         <!-- Pagination -->

--- a/prov-uk.php
+++ b/prov-uk.php
@@ -2,7 +2,8 @@
         define("TITLE", "Daten in");
 
   include('includes/arr_prov_uk.php');
-        include('includes/header.php');
+  include('includes/header.php');
+  include('config.php');
 
         function strip_bad_chars( $input ) {
                 $output = preg_replace("/[^a-zA-Z0-9_-]/", "",$input);
@@ -39,7 +40,7 @@
             <a :href="'profile.php?country=uk&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "https://16hl07csd16.nl/profile/province_age/uk/<?=$provuk['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('uk'); ?>/profile/province_age/uk/<?=$provuk['name']?>/18/45/120/S";
         </script>
 
         <!-- Pagination -->


### PR DESCRIPTION
## Summary
- extend `config.php` with UK and DE base URLs
- expose all API endpoint URLs via environment variables
- document API configuration in `README`

## Testing
- `npm test` *(fails: Missing script `test`)*
- `gulp` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac57beb988324a4c7b3fe479fbe2b