### PR TITLE
Update API config for AT and CH

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ country. Base URLs can be overridden using environment variables:
 - `API_BASE_URL_DEFAULT` - default API endpoint
 - `API_BASE_URL_BE` - Belgium specific endpoint
 - `API_BASE_URL_UK` - United Kingdom specific endpoint
-- `API_BASE_URL_DE` - Germany specific endpoint
+ - `API_BASE_URL_DE` - Germany specific endpoint, also used for Austria (`AT`) and Switzerland (`CH`)

--- a/config.php
+++ b/config.php
@@ -29,6 +29,8 @@ function api_base($country = '') {
         case 'uk':
             return $API_BASE_UK;
         case 'de':
+        case 'at':
+        case 'ch':
             return $API_BASE_DE;
         default:
             return $API_BASE_DEFAULT;


### PR DESCRIPTION
## Summary
- use the German API endpoint for Austria and Switzerland
- document this new mapping in README

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac86d6888832484e5522913152f93