### PR TITLE
Fix country parameter for profile page

### DIFF
--- a/profile.php
+++ b/profile.php
@@ -44,6 +44,16 @@
       $api_url = api_base('be') . '/profile/get0/7/';
       $ref_id = '32';
       break;
+    case 'de':
+    case 'at':
+    case 'ch':
+      $api_url = api_base('de') . '/profile/get/';
+      $ref_id = '32';
+      break;
+    case 'uk':
+      $api_url = api_base('uk') . '/profile/get/';
+      $ref_id = '32';
+      break;
     default:
       $api_url = api_base() . '/profile/get/';
       $ref_id = '32';


### PR DESCRIPTION
## Summary
- correctly handle `country` values for DE, AT, CH and UK in `profile.php`

## Testing
- `npm test` *(fails: Missing script)*
- `php -l profile.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acba20798832483d0704cb0e8ee10