### PR TITLE
Fix API URL encoding

### DIFF
--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -27,12 +27,16 @@ var oproepjes= new Vue({
         init: function(){
             axios.get(api_url)
                 .then(function(response){
-                    oproepjes.profiles = response.data.profiles.map(function(p){
-                        if(p.src && p.src.indexOf('no_img_Vrouw.jpg') !== -1){
-                            p.src = 'img/fallback.svg';
-                        }
-                        return p;
-                    });
+                    if(response.data && Array.isArray(response.data.profiles)){
+                        oproepjes.profiles = response.data.profiles.map(function(p){
+                            if(p.src && p.src.indexOf('no_img_Vrouw.jpg') !== -1){
+                                p.src = 'img/fallback.svg';
+                            }
+                            return p;
+                        });
+                    } else {
+                        console.error('Invalid profile data', response.data);
+                    }
                 })
                 .catch(function (error) {
                     console.log(error);

--- a/prov-at.php
+++ b/prov-at.php
@@ -40,7 +40,7 @@
         </div>  
     </div><!-- /.row -->
     <script>
-        var api_url= "<?= api_base('at'); ?>/profile/province_age/at/<?=$provat['name']?>/18/45/120/S";
+        var api_url= "<?= api_base('at'); ?>/profile/province_age/at/<?= rawurlencode($provat['name']); ?>/18/45/120/S";
     </script>
 
     <!-- Pagination -->

--- a/prov-be.php
+++ b/prov-be.php
@@ -44,8 +44,8 @@
         </div>
       </div>
       <script>
-        var api_url= "<?= api_base('be'); ?>/profile/province_age/be/<?=$provbe['name']?>/18/45/120/S";
-      </script> 
+        var api_url= "<?= api_base('be'); ?>/profile/province_age/be/<?= rawurlencode($provbe['name']); ?>/18/45/120/S";
+      </script>
     </div><!-- /.row -->
     <!-- Pagination -->
     <nav class="nav-pag" aria-label="Page navigation">

--- a/prov-ch.php
+++ b/prov-ch.php
@@ -39,7 +39,7 @@
             <a :href="'profile.php?country=ch&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "<?= api_base('ch'); ?>/profile/province_age/ch/<?=$provch['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('ch'); ?>/profile/province_age/ch/<?= rawurlencode($provch['name']); ?>/18/45/120/S";
         </script>
     </div><!-- /.row -->
     <!-- Pagination -->

--- a/prov-de.php
+++ b/prov-de.php
@@ -39,7 +39,7 @@
             <a :href="'profile.php?country=de&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "<?= api_base('de'); ?>/profile/province_age/de/<?=$provde['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('de'); ?>/profile/province_age/de/<?= rawurlencode($provde['name']); ?>/18/45/120/S";
         </script>
     </div><!-- /.row -->
     <!-- Pagination -->

--- a/prov-nl.php
+++ b/prov-nl.php
@@ -40,7 +40,7 @@
             <a :href="'profile.php?country=nl&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "<?= api_base('nl'); ?>/profile/province_age/nl/<?=$provnl['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('nl'); ?>/profile/province_age/nl/<?= rawurlencode($provnl['name']); ?>/18/45/120/S";
         </script>
     </div><!-- /.row -->
     <!-- Pagination -->

--- a/prov-uk.php
+++ b/prov-uk.php
@@ -39,7 +39,7 @@
             <a :href="'profile.php?country=uk&id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a></div>
         </div>
         <script>
-            var api_url= "<?= api_base('uk'); ?>/profile/province_age/uk/<?=$provuk['name']?>/18/45/120/S";
+            var api_url= "<?= api_base('uk'); ?>/profile/province_age/uk/<?= rawurlencode($provuk['name']); ?>/18/45/120/S";
         </script>
     </div><!-- /.row -->
     <!-- Pagination -->


### PR DESCRIPTION
## Summary
- handle invalid response structures when fetching profiles
- URL encode province names for API calls across all country pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ae86cc7b08324a3dd49897609801a