### PR TITLE
Fix canonical URLs

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -63,6 +63,7 @@
 <?php
 if(isset($_GET['item'])){
   $item = filter_var($_GET['item'], FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+  $item = preg_replace('/^sexdate-/', '', $item);
   echo '<link rel="canonical" href="https://18date.net/sexdate-'.$item.'" >';
   echo '<title>Sexdate '.$item.' | 18Date.net</title>';
 } else if(isset($_GET['id'])){


### PR DESCRIPTION
## Summary
- remove `sexdate-` prefix from `item` so canonical URLs don't redirect

## Testing
- `npm run` *(fails: Unknown env config)*

------
https://chatgpt.com/codex/tasks/task_e_684af7e1b4348324a7272c0823e1d0f5