### PR TITLE
Fix API error when api_url is undefined

### DIFF
--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -25,6 +25,10 @@ var oproepjes= new Vue({
     },
     methods:  {
         init: function(){
+            if (typeof api_url === 'undefined') {
+                // Skip API call when no endpoint is defined on the page
+                return;
+            }
             axios.get(api_url)
                 .then(function(response){
                     if(response.data && Array.isArray(response.data.profiles)){


### PR DESCRIPTION
## Summary
- avoid calling the API when `api_url` isn't defined

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b01d67e9c8324817e401a7750966a