### PR TITLE
Add Datingtips dropdown navigation

### DIFF
--- a/includes/nav.php
+++ b/includes/nav.php
@@ -63,4 +63,14 @@
                         ?>
                 </div>
         </li>
+        <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle drpdwn" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Datingtips</a>
+                <div class="dropdown-menu" aria-labelledby="navbarDropdown">
+                        <?php
+                        foreach ($navItemsTips as $item) {
+                                echo "<a class=\"dropdown-item\" href=\"$item[slug]\">$item[title]</a>";
+                        }
+                        ?>
+                </div>
+        </li>
 </ul>

--- a/includes/nav_items.php
+++ b/includes/nav_items.php
@@ -95,5 +95,16 @@ $navItemsCH = array(
 	array('slug' => 'sexdate-valais','title' => 'Valais'),        
 	array('slug' => 'sexdate-vaud','title' => 'Vaud'),        
 	array('slug' => 'sexdate-zug','title' => 'Zug'),        
-	array('slug' => 'sexdate-zurich','title' => 'Zürich'),
-);?>
+        array('slug' => 'sexdate-zurich','title' => 'Zürich'),
+);
+
+$navItemsTips = array(
+        array('slug' => 'datingtips.php?item=datingtips','title' => 'Datingtips'),
+        array('slug' => 'datingtips.php?item=nl','title' => 'Datingtips Nederland'),
+        array('slug' => 'datingtips.php?item=be','title' => 'Datingtips België'),
+        array('slug' => 'datingtips.php?item=de','title' => 'Datingtips Duitsland'),
+        array('slug' => 'datingtips.php?item=uk','title' => 'Datingtips Verenigd Koninkrijk'),
+        array('slug' => 'datingtips.php?item=at','title' => 'Datingtips Oostenrijk'),
+        array('slug' => 'datingtips.php?item=ch','title' => 'Datingtips Zwitserland'),
+);
+?>


### PR DESCRIPTION
## Summary
- define `$navItemsTips` in `nav_items.php` with links to specific dating tips pages
- render a new "Datingtips" dropdown in the site navigation

## Testing
- `npm test` *(fails: Missing script and network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6851649dd29c832499d8865f8c29acec