### PR TITLE
Fix nav arrays on 404 page

### DIFF
--- a/404.php
+++ b/404.php
@@ -11,12 +11,12 @@
           	<p>	Redenen hiervoor kunnen zijn:<br />1. Het profiel dat je probeert te benaderen bestaat niet meer.<br />2. Het webadres is niet correct ingevoerd.<br /><br />Gebruik het menu op deze pagina om een nieuwe keuze te maken.</p>
         	<a href="index.php" class="btn btn-primary"> Startpagina </a>
 		  	<?php
-		    	foreach ($navItems as $item) {
-		        echo "<a class=\"btn btn-primary\" href=\"$item[slug]\" style=\"margin: 1px;\">$item[title]</a>";
-		     	}
-		    ?>
-		    <?php
-            foreach ($navItems2 as $item2) {
+                        foreach ($navItemsNL as $item) {
+                        echo "<a class=\"btn btn-primary\" href=\"$item[slug]\" style=\"margin: 1px;\">$item[title]</a>";
+                        }
+                    ?>
+                    <?php
+            foreach ($navItemsBE as $item2) {
                 echo "<a class=\"btn btn-primary\" href=\"$item2[slug]\" style=\"margin: 1px;\">$item2[title]</a>";
             }
           ?>


### PR DESCRIPTION
## Summary
- use existing nav arrays on the 404 page

## Testing
- `php -l 404.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685178b7863c8324a688ad1a6e974db3