### PR TITLE
Add country-specific pages and update index layout

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -29,6 +29,14 @@ RewriteRule ^datingtips-verenigd-koninkrijk/?$ datingtips.php?item=uk [L,QSA]
 RewriteRule ^datingtips-oostenrijk/?$ datingtips.php?item=at [L,QSA]
 RewriteRule ^datingtips-zwitserland/?$ datingtips.php?item=ch [L,QSA]
 
+# Country pages
+RewriteRule ^sexdate-nederland/?$ nederland.php [L,QSA]
+RewriteRule ^sexdate-belgie/?$ belgie.php [L,QSA]
+RewriteRule ^sexdate-verenigd-koninkrijk/?$ verenigd-koninkrijk.php [L,QSA]
+RewriteRule ^sexdate-duitsland/?$ duitsland.php [L,QSA]
+RewriteRule ^sexdate-oostenrijk/?$ oostenrijk.php [L,QSA]
+RewriteRule ^sexdate-zwitserland/?$ zwitserland.php [L,QSA]
+
 # Profile slugs
 RewriteRule ^shemale-([a-z0-9-]+)/?$ profile.php?slug=$1 [L,QSA]
 

--- a/belgie.php
+++ b/belgie.php
@@ -1,0 +1,30 @@
+<?php
+$base = __DIR__;
+define("TITLE", "Sexdate België");
+include $base . '/includes/arr_prov_be.php';
+$canonical = 'https://18date.net/sexdate-belgie';
+$pageTitle = 'Sexdate België | 18Date.net';
+include $base . '/includes/header.php';
+?>
+<div class="container">
+  <h2 class="jumbotron text-center" id="belgie">Sexdate België</h2>
+  <div class="row text-center" id="keuze">
+    <?php
+      foreach ($be as $provbe => $item) {
+          $slug = ($provbe === 'limburg') ? 'sexdate-limburg-be' : 'sexdate-' . $provbe;
+    ?>
+    <div class="col-lg-3 col-md-6 mb-4">
+      <div class="card h-100 text-left">
+        <a href="<?php echo $slug; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
+        <div class="card-body">
+          <a href="<?php echo $slug; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
+          <hr>
+          <p class="card-text"><?php echo $item['info']; ?></p>
+        </div>
+        <a href="<?php echo $slug; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
+      </div>
+    </div>
+    <?php } ?>
+  </div>
+</div><!-- container -->
+<?php include $base . '/includes/footer.php'; ?>

--- a/duitsland.php
+++ b/duitsland.php
@@ -1,0 +1,27 @@
+<?php
+$base = __DIR__;
+define("TITLE", "Sexdate Duitsland");
+include $base . '/includes/arr_prov_de.php';
+$canonical = 'https://18date.net/sexdate-duitsland';
+$pageTitle = 'Sexdate Duitsland | 18Date.net';
+include $base . '/includes/header.php';
+?>
+<div class="container">
+  <h2 class="jumbotron text-center" id="duitsland">Sexdate Duitsland</h2>
+  <div class="row text-center" id="keuze">
+    <?php foreach ($de as $provde => $item) { ?>
+    <div class="col-lg-3 col-md-6 mb-4">
+      <div class="card h-100 text-left">
+        <a href="sexdate-<?php echo $provde; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
+        <div class="card-body">
+          <a href="sexdate-<?php echo $provde; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
+          <hr>
+          <p class="card-text"><?php echo $item['info']; ?></p>
+        </div>
+        <a href="sexdate-<?php echo $provde; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
+      </div>
+    </div>
+    <?php } ?>
+  </div>
+</div><!-- container -->
+<?php include $base . '/includes/footer.php'; ?>

--- a/index.php
+++ b/index.php
@@ -1,13 +1,6 @@
 <?php
 $base = __DIR__;
 	define("TITLE", "Home");
-  include $base . '/includes/arr_prov_nl.php';
-  include $base . '/includes/arr_prov_be.php';
-  include $base . '/includes/arr_prov_uk.php';
-  include $base . '/includes/arr_prov_de.php';
-  include $base . '/includes/arr_prov_at.php';
-  include $base . '/includes/arr_prov_ch.php';
-  include $base . '/includes/array_tips.php';
   include $base . '/includes/header.php';
 ?>
 
@@ -75,119 +68,241 @@ $base = __DIR__;
               echo "<a class=\"dropdown-item\" href=\"$item[slug]\">$item[title]</a>";
           }
         ?>
-      </div>
-    </div>
-    <p><a href="index.php">18date.net</a> is de contactadvertentie website om <b>snel en gratis</b> in contact te komen met jonge <b>vrouwen bij jou in de buurt</b>. Hier kun je jezelf <b>anoniem en gratis inschrijven</b> met een zelfgekozen profielnaam. Ook blijft je e-mailadres altijd geheim voor andere leden. Voor wie echt helemaal anoniem wil blijven, bestaat de mogelijkheid om geen foto op het profiel te tonen.</p>
-    <p>Of je nou bewust op zoek bent naar een eenmalige sexdate of geregeld wil afspreken met dames voor een meerdere sexdates? Op <a href="index.php">18date.net</a> vind je <b>meer dan 10.000 single vrouwen die openstaan voor een sexdate</b>. Duizenden singles zijn op dit moment op zoek naar een sexdate, een sexpartner of meerdere sexdates. Van zoeken naar een sexdate binnen enkele dagen, gelijk sex bij jou in de buurt tot meerdere sexdates in een week. Bij <a href="index.php">18date.net</a> heb jij het snelst een sexdate in de BeNeLux! Kies in welk land jij wil zoeken naar een sexdate.</p>
-  </div>
-  <div id="top-banner"></div>
-  <h2 class="jumbotron text-center" id="nederland">Sexdate Nederland</h2>
-  <div class="row text-center" id="keuze">
-    <?php 
-      foreach ($nl as $provnl => $item) {
-          $slug = ($provnl === 'limburg') ? 'sexdate-limburg-nl' : 'sexdate-' . $provnl;
-    ?>
-    <div class="col-lg-3 col-md-6 mb-4">
-      <div class="card h-100 text-left">
-        <a href="<?php echo $slug; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
-        <div class="card-body">
-          <a href="<?php echo $slug; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
-          <hr>
-          <p class="card-text"><?php echo $item['info']; ?></p>
         </div>
-        <a href="<?php echo $slug; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
-      </div>
+<div class="jumbotron jumbotron-sm text-center">
+        <h2>Nieuwste leden Nederland op zoek naar een sexdate!</h2>
     </div>
-    <?php
-      }
-    ?>
-  </div>
-
-  <h2 class="jumbotron text-center" id="belgie">Sexdate België</h2>
-  <div class="row text-center" id="keuze">
-    <?php
-      foreach ($be as $provbe => $item) {
-      $slug = ($provbe === 'limburg') ? 'sexdate-limburg-be' : 'sexdate-' . $provbe;
-    ?>
-    <div class="col-lg-3 col-md-6 mb-4">
-      <div class="card h-100 text-left">
-        <a href="<?php echo $slug; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
-        <div class="card-body">
-          <a href="<?php echo $slug; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
-          <hr>
-          <p class="card-text"><?php echo $item['info']; ?></p>
+    <div class="row" v-cloak>
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+            <div class="card h-100">
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'" @error="imgError"></a>
+                <div class="card-body">
+                    <div class="card-top">
+                        <h4 class="card-title">{{ profile.name }}</h4>  
+                    </div>
+                    <ul class="list-group">
+                        <li class="list-group-item">Leeftijd: {{ profile.age }}</li>
+                        <li class="list-group-item">Relatie: {{ profile.relationship }}</li>
+                        <li class="list-group-item">Stad: {{ profile.city }}</li>
+                        <li class="list-group-item">Provincie: {{ profile.province }}</li>
+                    </ul>
+                </div>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
+            </div>
         </div>
-        <a href="<?php echo $slug; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
-      </div>
+        <script>
+            var api_url= "<?= api_base('nl'); ?>/profile/latest/nl";
+        </script>
+        <!-- Pagination -->
+        <nav class="nav-pag" aria-label="Page navigation">
+            <ul class="pagination flex-wrap justify-content-center">
+                <li class="page-item">
+                    <a class="page-link" aria-label="Vorige" v-on:click="set_page_number(page-1)" ><span aria-hidden="true">&laquo;</span><span class="sr-only">Vorige</span></a>
+                </li> 
+                <li v-for="page_number in max_page_number" class="page-item" v-bind:class="{ active: page_number == page }" >
+                  <a class="page-link" v-on:click="set_page_number(page_number)">{{ page_number }}</a>
+                </li> 
+                <li class="page-item">
+                  <a class="page-link" aria-label="Volgende" v-on:click="set_page_number(page+1)" ><span aria-hidden="true">&raquo;</span><span class="sr-only">Volgende</span></a>
+                </li>
+            </ul>
+        </nav>
+    </div><!-- /.row -->
+<div class="jumbotron jumbotron-sm text-center">
+        <h2>Nieuwste leden België op zoek naar een sexdate!</h2>
     </div>
-    <?php
-      }
-    ?>
-  </div>
-  <h2 class="jumbotron text-center" id="uk">Sexdate United Kingdom</h2>
-  <div class="row text-center" id="keuze">
-    <?php foreach ($uk as $provuk => $item) { ?>
-    <div class="col-lg-3 col-md-6 mb-4">
-      <div class="card h-100 text-left">
-        <a href="sexdate-<?php echo $provuk; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
-        <div class="card-body">
-          <a href="sexdate-<?php echo $provuk; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
-          <hr>
-          <p class="card-text"><?php echo $item['info']; ?></p>
+    <div class="row" v-cloak>
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+            <div class="card h-100">
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in België'" @error="imgError"></a>
+                <div class="card-body">
+                    <div class="card-top">
+                        <h4 class="card-title">{{ profile.name }}</h4>
+                    </div>
+                    <ul class="list-group">
+                        <li class="list-group-item">Leeftijd: {{ profile.age }}</li>
+                        <li class="list-group-item">Relatie: {{ profile.relationship }}</li>
+                        <li class="list-group-item">Stad: {{ profile.city }}</li>
+                        <li class="list-group-item">Provincie: {{ profile.province }}</li>
+                    </ul>
+                </div>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
+            </div>
         </div>
-        <a href="sexdate-<?php echo $provuk; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
-      </div>
+        <script>
+            var api_url= "<?= api_base('be'); ?>/profile/latest/be";
+        </script>
+        <!-- Pagination -->
+        <nav class="nav-pag" aria-label="Page navigation">
+            <ul class="pagination flex-wrap justify-content-center">
+                <li class="page-item">
+                    <a class="page-link" aria-label="Vorige" v-on:click="set_page_number(page-1)" ><span aria-hidden="true">&laquo;</span><span class="sr-only">Vorige</span></a>
+                </li> 
+                <li v-for="page_number in max_page_number" class="page-item" v-bind:class="{ active: page_number == page }" >
+                  <a class="page-link" v-on:click="set_page_number(page_number)">{{ page_number }}</a>
+                </li> 
+                <li class="page-item">
+                  <a class="page-link" aria-label="Volgende" v-on:click="set_page_number(page+1)" ><span aria-hidden="true">&raquo;</span><span class="sr-only">Volgende</span></a>
+                </li>
+            </ul>
+        </nav>
+    </div><!-- /.row -->
+<div class="jumbotron jumbotron-sm text-center">
+        <h2>Nieuwste leden United Kingdom op zoek naar een sexdate!</h2>
     </div>
-    <?php } ?>
-  </div>
-  <h2 class="jumbotron text-center" id="duitsland">Sexdate Duitsland</h2>
-  <div class="row text-center" id="keuze">
-    <?php foreach ($de as $provde => $item) { ?>
-    <div class="col-lg-3 col-md-6 mb-4">
-      <div class="card h-100 text-left">
-        <a href="sexdate-<?php echo $provde; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
-        <div class="card-body">
-          <a href="sexdate-<?php echo $provde; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
-          <hr>
-          <p class="card-text"><?php echo $item['info']; ?></p>
+    <div class="row" v-cloak>
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+            <div class="card h-100">
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in United Kingdom'" @error="imgError"></a>
+                <div class="card-body">
+                    <div class="card-top">
+                        <h4 class="card-title">{{ profile.name }}</h4>
+                    </div>
+                    <ul class="list-group">
+                        <li class="list-group-item">Leeftijd: {{ profile.age }}</li>
+                        <li class="list-group-item">Relatie: {{ profile.relationship }}</li>
+                        <li class="list-group-item">Stad: {{ profile.city }}</li>
+                        <li class="list-group-item">Regio: {{ profile.province }}</li>
+                    </ul>
+                </div>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
+            </div>
         </div>
-        <a href="sexdate-<?php echo $provde; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
-      </div>
+        <script>
+            var api_url= "<?= api_base('uk'); ?>/profile/latest/uk";
+        </script>
+        <!-- Pagination -->
+        <nav class="nav-pag" aria-label="Page navigation">
+            <ul class="pagination flex-wrap justify-content-center">
+                <li class="page-item">
+                    <a class="page-link" aria-label="Vorige" v-on:click="set_page_number(page-1)" ><span aria-hidden="true">&laquo;</span><span class="sr-only">Vorige</span></a>
+                </li> 
+                <li v-for="page_number in max_page_number" class="page-item" v-bind:class="{ active: page_number == page }" >
+                  <a class="page-link" v-on:click="set_page_number(page_number)">{{ page_number }}</a>
+                </li> 
+                <li class="page-item">
+                  <a class="page-link" aria-label="Volgende" v-on:click="set_page_number(page+1)" ><span aria-hidden="true">&raquo;</span><span class="sr-only">Volgende</span></a>
+                </li>
+            </ul>
+        </nav>
+    </div><!-- /.row -->
+<div class="jumbotron jumbotron-sm text-center">
+        <h2>Nieuwste leden Duitsland op zoek naar een sexdate!</h2>
     </div>
-    <?php } ?>
-  </div>
-  <h2 class="jumbotron text-center" id="oostenrijk">Sexdate Oostenrijk</h2>
-  <div class="row text-center" id="keuze">
-    <?php foreach ($at as $provat => $item) { ?>
-    <div class="col-lg-3 col-md-6 mb-4">
-      <div class="card h-100 text-left">
-        <a href="sexdate-<?php echo $provat; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
-        <div class="card-body">
-          <a href="sexdate-<?php echo $provat; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
-          <hr>
-          <p class="card-text"><?php echo $item['info']; ?></p>
+    <div class="row" v-cloak>
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+            <div class="card h-100">
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Duitsland'" @error="imgError"></a>
+                <div class="card-body">
+                    <div class="card-top">
+                        <h4 class="card-title">{{ profile.name }}</h4>
+                    </div>
+                    <ul class="list-group">
+                        <li class="list-group-item">Leeftijd: {{ profile.age }}</li>
+                        <li class="list-group-item">Relatie: {{ profile.relationship }}</li>
+                        <li class="list-group-item">Stad: {{ profile.city }}</li>
+                        <li class="list-group-item">Provincie: {{ profile.province }}</li>
+                    </ul>
+                </div>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
+            </div>
         </div>
-        <a href="sexdate-<?php echo $provat; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
-      </div>
+        <script>
+            var api_url= "<?= api_base('de'); ?>/profile/latest/de";
+        </script>
+        <!-- Pagination -->
+        <nav class="nav-pag" aria-label="Page navigation">
+            <ul class="pagination flex-wrap justify-content-center">
+                <li class="page-item">
+                    <a class="page-link" aria-label="Vorige" v-on:click="set_page_number(page-1)" ><span aria-hidden="true">&laquo;</span><span class="sr-only">Vorige</span></a>
+                </li> 
+                <li v-for="page_number in max_page_number" class="page-item" v-bind:class="{ active: page_number == page }" >
+                  <a class="page-link" v-on:click="set_page_number(page_number)">{{ page_number }}</a>
+                </li> 
+                <li class="page-item">
+                  <a class="page-link" aria-label="Volgende" v-on:click="set_page_number(page+1)" ><span aria-hidden="true">&raquo;</span><span class="sr-only">Volgende</span></a>
+                </li>
+            </ul>
+        </nav>
+    </div><!-- /.row -->
+<div class="jumbotron jumbotron-sm text-center">
+        <h2>Nieuwste leden Oostenrijk op zoek naar een sexdate!</h2>
     </div>
-    <?php } ?>
-  </div>
-  <h2 class="jumbotron text-center" id="zwitserland">Sexdate Zwitserland</h2>
-  <div class="row text-center" id="keuze">
-    <?php foreach ($ch as $provch => $item) { ?>
-    <div class="col-lg-3 col-md-6 mb-4">
-      <div class="card h-100 text-left">
-        <a href="sexdate-<?php echo $provch; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
-        <div class="card-body">
-          <a href="sexdate-<?php echo $provch; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
-          <hr>
-          <p class="card-text"><?php echo $item['info']; ?></p>
+    <div class="row" v-cloak>
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+            <div class="card h-100">
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Oostenrijk'" @error="imgError"></a>
+                <div class="card-body">
+                    <div class="card-top">
+                        <h4 class="card-title">{{ profile.name }}</h4>
+                    </div>
+                    <ul class="list-group">
+                        <li class="list-group-item">Leeftijd: {{ profile.age }}</li>
+                        <li class="list-group-item">Relatie: {{ profile.relationship }}</li>
+                        <li class="list-group-item">Stad: {{ profile.city }}</li>
+                        <li class="list-group-item">Provincie: {{ profile.province }}</li>
+                    </ul>
+                </div>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
+            </div>
         </div>
-        <a href="sexdate-<?php echo $provch; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
-      </div>
+        <script>
+            var api_url= "<?= api_base('at'); ?>/profile/latest/at";
+        </script>
+        <!-- Pagination -->
+        <nav class="nav-pag" aria-label="Page navigation">
+            <ul class="pagination flex-wrap justify-content-center">
+                <li class="page-item">
+                    <a class="page-link" aria-label="Vorige" v-on:click="set_page_number(page-1)" ><span aria-hidden="true">&laquo;</span><span class="sr-only">Vorige</span></a>
+                </li> 
+                <li v-for="page_number in max_page_number" class="page-item" v-bind:class="{ active: page_number == page }" >
+                  <a class="page-link" v-on:click="set_page_number(page_number)">{{ page_number }}</a>
+                </li> 
+                <li class="page-item">
+                  <a class="page-link" aria-label="Volgende" v-on:click="set_page_number(page+1)" ><span aria-hidden="true">&raquo;</span><span class="sr-only">Volgende</span></a>
+                </li>
+            </ul>
+        </nav>
+    </div><!-- /.row -->
+<div class="jumbotron jumbotron-sm text-center">
+        <h2>Nieuwste leden Zwitserland op zoek naar een sexdate!</h2>
     </div>
-    <?php } ?>
-  </div>
+    <div class="row" v-cloak>
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+            <div class="card h-100">
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Zwitserland'" @error="imgError"></a>
+                <div class="card-body">
+                    <div class="card-top">
+                        <h4 class="card-title">{{ profile.name }}</h4>
+                    </div>
+                    <ul class="list-group">
+                        <li class="list-group-item">Leeftijd: {{ profile.age }}</li>
+                        <li class="list-group-item">Relatie: {{ profile.relationship }}</li>
+                        <li class="list-group-item">Stad: {{ profile.city }}</li>
+                        <li class="list-group-item">Regio: {{ profile.province }}</li>
+                    </ul>
+                </div>
+                <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id" class="card-footer btn btn-primary">Bekijk profiel</a>
+            </div>
+        </div>
+        <script>
+            var api_url= "<?= api_base('ch'); ?>/profile/latest/ch";
+        </script>
+        <!-- Pagination -->
+        <nav class="nav-pag" aria-label="Page navigation">
+            <ul class="pagination flex-wrap justify-content-center">
+                <li class="page-item">
+                    <a class="page-link" aria-label="Vorige" v-on:click="set_page_number(page-1)" ><span aria-hidden="true">&laquo;</span><span class="sr-only">Vorige</span></a>
+                </li> 
+                <li v-for="page_number in max_page_number" class="page-item" v-bind:class="{ active: page_number == page }" >
+                  <a class="page-link" v-on:click="set_page_number(page_number)">{{ page_number }}</a>
+                </li> 
+                <li class="page-item">
+                  <a class="page-link" aria-label="Volgende" v-on:click="set_page_number(page+1)" ><span aria-hidden="true">&raquo;</span><span class="sr-only">Volgende</span></a>
+                </li>
+            </ul>
+        </nav>
+    </div><!-- /.row -->
   <div id="footer-banner"></div>
   <div class="jumbotron text-center">
       <h6>Nederland</h6>

--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -1,3 +1,12 @@
+function slugify(str){
+    return str.toString().toLowerCase()
+        .replace(/\s+/g,'-')
+        .replace(/[^\w-]+/g,'')
+        .replace(/--+/g,'-')
+        .replace(/^-+/, '')
+        .replace(/-+$/, '');
+}
+
 var oproepjes= new Vue({
     el: "#oproepjes",
     created: function(){

--- a/nederland.php
+++ b/nederland.php
@@ -1,0 +1,30 @@
+<?php
+$base = __DIR__;
+define("TITLE", "Sexdate Nederland");
+include $base . '/includes/arr_prov_nl.php';
+$canonical = 'https://18date.net/sexdate-nederland';
+$pageTitle = 'Sexdate Nederland | 18Date.net';
+include $base . '/includes/header.php';
+?>
+<div class="container">
+  <h2 class="jumbotron text-center" id="nederland">Sexdate Nederland</h2>
+  <div class="row text-center" id="keuze">
+    <?php
+      foreach ($nl as $provnl => $item) {
+          $slug = ($provnl === 'limburg') ? 'sexdate-limburg-nl' : 'sexdate-' . $provnl;
+    ?>
+    <div class="col-lg-3 col-md-6 mb-4">
+      <div class="card h-100 text-left">
+        <a href="<?php echo $slug; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
+        <div class="card-body">
+          <a href="<?php echo $slug; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
+          <hr>
+          <p class="card-text"><?php echo $item['info']; ?></p>
+        </div>
+        <a href="<?php echo $slug; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
+      </div>
+    </div>
+    <?php } ?>
+  </div>
+</div><!-- container -->
+<?php include $base . '/includes/footer.php'; ?>

--- a/oostenrijk.php
+++ b/oostenrijk.php
@@ -1,0 +1,27 @@
+<?php
+$base = __DIR__;
+define("TITLE", "Sexdate Oostenrijk");
+include $base . '/includes/arr_prov_at.php';
+$canonical = 'https://18date.net/sexdate-oostenrijk';
+$pageTitle = 'Sexdate Oostenrijk | 18Date.net';
+include $base . '/includes/header.php';
+?>
+<div class="container">
+  <h2 class="jumbotron text-center" id="oostenrijk">Sexdate Oostenrijk</h2>
+  <div class="row text-center" id="keuze">
+    <?php foreach ($at as $provat => $item) { ?>
+    <div class="col-lg-3 col-md-6 mb-4">
+      <div class="card h-100 text-left">
+        <a href="sexdate-<?php echo $provat; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
+        <div class="card-body">
+          <a href="sexdate-<?php echo $provat; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
+          <hr>
+          <p class="card-text"><?php echo $item['info']; ?></p>
+        </div>
+        <a href="sexdate-<?php echo $provat; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
+      </div>
+    </div>
+    <?php } ?>
+  </div>
+</div><!-- container -->
+<?php include $base . '/includes/footer.php'; ?>

--- a/verenigd-koninkrijk.php
+++ b/verenigd-koninkrijk.php
@@ -1,0 +1,27 @@
+<?php
+$base = __DIR__;
+define("TITLE", "Sexdate United Kingdom");
+include $base . '/includes/arr_prov_uk.php';
+$canonical = 'https://18date.net/sexdate-verenigd-koninkrijk';
+$pageTitle = 'Sexdate United Kingdom | 18Date.net';
+include $base . '/includes/header.php';
+?>
+<div class="container">
+  <h2 class="jumbotron text-center" id="uk">Sexdate United Kingdom</h2>
+  <div class="row text-center" id="keuze">
+    <?php foreach ($uk as $provuk => $item) { ?>
+    <div class="col-lg-3 col-md-6 mb-4">
+      <div class="card h-100 text-left">
+        <a href="sexdate-<?php echo $provuk; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
+        <div class="card-body">
+          <a href="sexdate-<?php echo $provuk; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
+          <hr>
+          <p class="card-text"><?php echo $item['info']; ?></p>
+        </div>
+        <a href="sexdate-<?php echo $provuk; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
+      </div>
+    </div>
+    <?php } ?>
+  </div>
+</div><!-- container -->
+<?php include $base . '/includes/footer.php'; ?>

--- a/zwitserland.php
+++ b/zwitserland.php
@@ -1,0 +1,27 @@
+<?php
+$base = __DIR__;
+define("TITLE", "Sexdate Zwitserland");
+include $base . '/includes/arr_prov_ch.php';
+$canonical = 'https://18date.net/sexdate-zwitserland';
+$pageTitle = 'Sexdate Zwitserland | 18Date.net';
+include $base . '/includes/header.php';
+?>
+<div class="container">
+  <h2 class="jumbotron text-center" id="zwitserland">Sexdate Zwitserland</h2>
+  <div class="row text-center" id="keuze">
+    <?php foreach ($ch as $provch => $item) { ?>
+    <div class="col-lg-3 col-md-6 mb-4">
+      <div class="card h-100 text-left">
+        <a href="sexdate-<?php echo $provch; ?>"><img class="card-img-top" src="img/front/<?php echo $item['img']; ?>.jpeg" alt="Sexdate <?php echo $item['name']; ?>" @error="imgError"></a>
+        <div class="card-body">
+          <a href="sexdate-<?php echo $provch; ?>"><h4 class="card-title"><?php echo $item['name']; ?></h4></a>
+          <hr>
+          <p class="card-text"><?php echo $item['info']; ?></p>
+        </div>
+        <a href="sexdate-<?php echo $provch; ?>" class="card-footer btn btn-primary">Sexdate <?php echo $item['name']; ?></a>
+      </div>
+    </div>
+    <?php } ?>
+  </div>
+</div><!-- container -->
+<?php include $base . '/includes/footer.php'; ?>


### PR DESCRIPTION
## Summary
- create new country overview pages
- update index.php to display latest members per country
- add slugify helper for profile links
- route new country slugs via .htaccess

## Testing
- `php` not available, so no syntax check was run

------
https://chatgpt.com/codex/tasks/task_e_68567007067883249b184a8f3e4b76bf