### PR TITLE
Fix variable variable dereference

### DIFF
--- a/land.php
+++ b/land.php
@@ -63,7 +63,7 @@ $data = [
 $info = $data[$country];
 
 include $base . $info['file'];
-$provArray = $$info['var'];
+$provArray = ${$info['var']};
 
 $canonical = $info['canonical'];
 $pageTitle = $info['pageTitle'];


### PR DESCRIPTION
## Summary
- correct PHP variable-variable syntax in `land.php`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68567ed0bd38832497cc01413099a3cf