### PR TITLE
Improve error handling for profile data

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -231,3 +231,8 @@ footer {
 .addthis_inline_follow_toolbox {
     margin-top: -5px;
 }
+
+/* Alert shown when profile data fails to load */
+.alert.data-error {
+    text-align: center;
+}

--- a/index.php
+++ b/index.php
@@ -75,6 +75,9 @@ $base = __DIR__;
         <h2>Nieuwste leden Nederland op zoek naar een sexdate!</h2>
     </div>
     <div class="row country-section" id="oproepjes-nl" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'" @error="imgError"></a>
@@ -116,6 +119,9 @@ $base = __DIR__;
         <h2>Nieuwste leden België op zoek naar een sexdate!</h2>
     </div>
     <div class="row country-section" id="oproepjes-be" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in België'" @error="imgError"></a>
@@ -157,6 +163,9 @@ $base = __DIR__;
         <h2>Nieuwste leden United Kingdom op zoek naar een sexdate!</h2>
     </div>
     <div class="row country-section" id="oproepjes-uk" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in United Kingdom'" @error="imgError"></a>
@@ -198,6 +207,9 @@ $base = __DIR__;
         <h2>Nieuwste leden Duitsland op zoek naar een sexdate!</h2>
     </div>
     <div class="row country-section" id="oproepjes-de" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Duitsland'" @error="imgError"></a>
@@ -239,6 +251,9 @@ $base = __DIR__;
         <h2>Nieuwste leden Oostenrijk op zoek naar een sexdate!</h2>
     </div>
     <div class="row country-section" id="oproepjes-at" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Oostenrijk'" @error="imgError"></a>
@@ -280,6 +295,9 @@ $base = __DIR__;
         <h2>Nieuwste leden Zwitserland op zoek naar een sexdate!</h2>
     </div>
     <div class="row country-section" id="oproepjes-ch" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Zwitserland'" @error="imgError"></a>

--- a/js/oproepjes.js
+++ b/js/oproepjes.js
@@ -17,7 +17,8 @@ function createOproepjes(el, apiUrl){
             profiles: [],
             page: 1,
             ppp: 20,    //profiles per page
-            api_url: apiUrl
+            api_url: apiUrl,
+            dataError: false
         },
     computed: {
         filtered_profiles: function(){
@@ -52,10 +53,12 @@ function createOproepjes(el, apiUrl){
                         });
                     } else {
                         console.error('Invalid profile data', response.data);
+                        that.dataError = true;
                     }
                 })
                 .catch(function (error) {
-                    console.log(error);
+                    console.error(error);
+                    that.dataError = true;
                 });
         },
         set_page_number: function(page){

--- a/prov-at.php
+++ b/prov-at.php
@@ -30,6 +30,9 @@ require_once $base . '/includes/utils.php';
         <p><?php echo $provat['info']; ?></p>
     </div>
     <div class="row" id="oproepjes-list" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=at&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name" @error="imgError"></a>

--- a/prov-be.php
+++ b/prov-be.php
@@ -31,6 +31,9 @@ include $base . '/includes/header.php';
 			<p><?php echo $provbe['info']; ?></p>
 		</div>
                 <div class="row" id="oproepjes-list" v-cloak>
+      <div class="col-12" v-if="dataError">
+          <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+      </div>
       <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
         <div class="card h-100">
           <a :href="'profile.php?country=be&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>

--- a/prov-ch.php
+++ b/prov-ch.php
@@ -30,6 +30,9 @@ include $base . '/includes/header.php';
         <p><?php echo $provch['info']; ?></p>
     </div>
     <div class="row" id="oproepjes-list" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=ch&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name" @error="imgError"></a>

--- a/prov-de.php
+++ b/prov-de.php
@@ -30,6 +30,9 @@ include $base . '/includes/header.php';
         <p><?php echo $provde['info']; ?></p>
     </div>
     <div class="row" id="oproepjes-list" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=de&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name" @error="imgError"></a>

--- a/prov-nl.php
+++ b/prov-nl.php
@@ -31,6 +31,9 @@ include $base . '/includes/header.php';
         <p><?php echo $provnl['info']; ?></p>
     </div>
     <div class="row" id="oproepjes-list" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=nl&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>

--- a/prov-uk.php
+++ b/prov-uk.php
@@ -30,6 +30,9 @@ include $base . '/includes/header.php';
         <p><?php echo $provuk['info']; ?></p>
     </div>
     <div class="row" id="oproepjes-list" v-cloak>
+        <div class="col-12" v-if="dataError">
+            <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
+        </div>
         <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=uk&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name" @error="imgError"></a>


### PR DESCRIPTION
## Summary
- flag API errors in `oproepjes.js`
- show an alert when profile data can't load
- style the alert message

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685682b1eb1883249424d5f239f165ae