### PR TITLE
Fix duplicate profile card ids

### DIFF
--- a/index.php
+++ b/index.php
@@ -78,7 +78,7 @@ $base = __DIR__;
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Nederland'" @error="imgError"></a>
                 <div class="card-body">
@@ -122,7 +122,7 @@ $base = __DIR__;
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in België'" @error="imgError"></a>
                 <div class="card-body">
@@ -166,7 +166,7 @@ $base = __DIR__;
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in United Kingdom'" @error="imgError"></a>
                 <div class="card-body">
@@ -210,7 +210,7 @@ $base = __DIR__;
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Duitsland'" @error="imgError"></a>
                 <div class="card-body">
@@ -254,7 +254,7 @@ $base = __DIR__;
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Oostenrijk'" @error="imgError"></a>
                 <div class="card-body">
@@ -298,7 +298,7 @@ $base = __DIR__;
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-6 mb-4 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-6 mb-4 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
             <div class="card h-100">
                 <a :href="'daten-met-' + slugify(profile.name) + '?id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Zwitserland'" @error="imgError"></a>
                 <div class="card-body">

--- a/prov-at.php
+++ b/prov-at.php
@@ -33,7 +33,7 @@ require_once $base . '/includes/utils.php';
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=at&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name" @error="imgError"></a>
             <div class="card-body">

--- a/prov-be.php
+++ b/prov-be.php
@@ -34,7 +34,7 @@ include $base . '/includes/header.php';
       <div class="col-12" v-if="dataError">
           <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
       </div>
-      <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+      <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
         <div class="card h-100">
           <a :href="'profile.php?country=be&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>
           <div class="card-body">

--- a/prov-ch.php
+++ b/prov-ch.php
@@ -33,7 +33,7 @@ include $base . '/includes/header.php';
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=ch&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name" @error="imgError"></a>
             <div class="card-body">

--- a/prov-de.php
+++ b/prov-de.php
@@ -33,7 +33,7 @@ include $base . '/includes/header.php';
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=de&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name" @error="imgError"></a>
             <div class="card-body">

--- a/prov-nl.php
+++ b/prov-nl.php
@@ -34,7 +34,7 @@ include $base . '/includes/header.php';
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=nl&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name + ' daten in Flevoland'" @error="imgError"></a>
             <div class="card-body">

--- a/prov-uk.php
+++ b/prov-uk.php
@@ -33,7 +33,7 @@ include $base . '/includes/header.php';
         <div class="col-12" v-if="dataError">
             <div class="alert alert-warning data-error">Profieldata kon niet geladen worden.</div>
         </div>
-        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item" id="Slankie" v-for="profile in filtered_profiles">
+        <div class="col-lg-3 col-md-4 col-sm-6 portfolio-item profile-card" :id="'profile-' + profile.id" v-for="profile in filtered_profiles">
         <div class="card h-100">
             <a :href="'profile.php?country=uk&id=' + profile.id"><img class="card-img-top" :src="profile.src.replace('150x150', '300x300')" :alt="profile.name" @error="imgError"></a>
             <div class="card-body">


### PR DESCRIPTION
## Summary
- remove static `id="Slankie"` from profile card templates
- assign dynamic IDs using Vue and add `.profile-card` class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685683ac76c883249286b95f354e4729