### PR TITLE
Ensure canonical uses slug if available

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -145,7 +145,11 @@
     }
     if($profile_name){
       $slug = slugify($profile_name);
-      $canonical = 'https://18date.net/date-' . $slug;
+      if($slug){
+        $canonical = 'https://18date.net/date-' . $slug;
+      } else {
+        $canonical = 'https://18date.net/profile?id=' . $id;
+      }
       $pageTitle = 'Date ' . htmlspecialchars($profile_name, ENT_QUOTES, 'UTF-8');
     } else {
       $canonical = 'https://18date.net/profile?id=' . $id;


### PR DESCRIPTION
## Summary
- if the profile API returns a name, slugify it and prefer `/date-{slug}` for the canonical URL
- only fall back to the `profile?id=` canonical when no name is provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6eb417fc8324a8ef092f02aeaef1