### PR TITLE
Remove ref param from profile canonical URLs

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -164,6 +164,10 @@
     $pageTitle = 'Date ' . $slugParam . ' | 18date.net';
   }
 
+  // Ensure any ref parameter is stripped from the canonical URL
+  $canonical = preg_replace('/([?&])ref=[^&]*(&|$)/', '$1', $canonical);
+  $canonical = rtrim($canonical, '?&');
+
   echo '<link rel="canonical" href="' . $canonical . '" >';
   echo '<title>' . htmlspecialchars($pageTitle, ENT_QUOTES, 'UTF-8') . '</title>';
   echo '<meta property="og:type" content="website">';

--- a/js/profile.js
+++ b/js/profile.js
@@ -22,6 +22,15 @@ function getSlugFromPath(){
     return match ? match[1] : null;
 }
 
+// Remove the ref parameter from a query string and return the remaining
+// search portion (including the leading '?') or an empty string if none remain
+function stripRefFromSearch() {
+    var params = new URLSearchParams(window.location.search);
+    params.delete('ref');
+    var s = params.toString();
+    return s ? '?' + s : '';
+}
+
 var profiel= new Vue({
     router,
     el: "#profiel",
@@ -74,7 +83,7 @@ var profiel= new Vue({
                     }
                     var slug = slugify(that.profile.name || '');
                     if(slug){
-                        var newUrl = '/date-' + slug;
+                        var newUrl = '/date-' + slug + stripRefFromSearch();
                         var link = document.querySelector('link[rel=canonical]');
                         if(link){
                             link.setAttribute('href', 'https://18date.net' + newUrl);


### PR DESCRIPTION
## Summary
- ensure canonical URLs strip `ref` query parameter
- update profile URL rewriting logic to drop `ref` when updating the page URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d6feddd6083248f0ce8d2ad701934